### PR TITLE
Fix missed or reverted change in concurrency check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
-WORKDIR /src
+WORKDIR /
+COPY . .
 
-COPY /src/GameOfLife .
-RUN dotnet publish -c Release -o ./../_publish
+RUN dotnet test && \
+    dotnet publish ./src/GameOfLife/GameOfLife.csproj -c Release -o ./../_publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
 
 WORKDIR /app
-COPY --from=build /../_publish .
+COPY --from=build ./../_publish .
 
 EXPOSE 8080
 

--- a/src/GameOfLife/Persistence/MongoBoardRepository.cs
+++ b/src/GameOfLife/Persistence/MongoBoardRepository.cs
@@ -19,7 +19,7 @@ public class MongoBoardRepository(IMongoCollection<Board> collection) : IBoardRe
 
     public async Task<bool> Update(Board board, long originalGeneration, CancellationToken cancellationToken)
     {
-        var result = await collection.ReplaceOneAsync(x => x.Id == board.Id && x.Generation == board.Generation, board, cancellationToken: cancellationToken);
+        var result = await collection.ReplaceOneAsync(x => x.Id == board.Id && x.Generation == originalGeneration, board, cancellationToken: cancellationToken);
         return result.ModifiedCount > 0;
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` and `MongoBoardRepository.cs` to improve the build process and fix a bug in the board update logic.

Improvements to build process:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R12): Changed the working directory setup and file copying strategy to streamline the build process and added a test step before publishing.

Bug fix:

* [`src/GameOfLife/Persistence/MongoBoardRepository.cs`](diffhunk://#diff-e35b0ead319ece29588adfffa362f239c156b54add4d980db8d3e4586c015574L22-R22): Fixed the `Update` method to use the `originalGeneration` parameter instead of the current generation of the board, ensuring that updates only occur if the board is in the expected state.